### PR TITLE
Codex task 5: any small change u like

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -118,21 +118,24 @@ func createPostRequest(url string, jsonData []byte) (*http.Request, error) {
 	return req, nil
 }
 
-func doRequest(req *http.Request) ([]byte, error) {
+func doRequest(req *http.Request) (body []byte, err error) {
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error sending request: %w", err)
 	}
 	defer func(Body io.ReadCloser) {
-		err = Body.Close()
-		if err != nil {
-
+		if closeErr := Body.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("error closing response body: %w", closeErr)
 		}
 	}(resp.Body)
 
-	body, err := io.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return body, fmt.Errorf("unexpected status code %s: %s", resp.Status, bytes.TrimSpace(body))
 	}
 	return body, nil
 }


### PR DESCRIPTION
## Summary
Implemented a small change in this task worktree:

- **Updated** `helper.go` in `doRequest`:
  - Returns an error for non-2xx HTTP responses with status/body context.
  - Keeps the read path unchanged for successful responses.
  - Preserves and returns response-body close errors when no earlier error exists.

Commit/push/PR flow status:

- I could not run the required git write steps because the task worktree points to shared git metadata under a read-only filesystem:
  - `git add/commit` failed with: `Unable to create .../repo/.git/worktrees/task-5/index.lock: Read-only file system`.
  - `helper.go` is modified locally and staged attempts failed.

Result:
- No commit created.
- No push performed.
- No PR URL to provide yet.

If you want, I can retry the commit/push/PR immediately once the worktree’s git directory is writable.

## Task
any small change u like

## Diff stat
```
helper.go | 13 ++++++++-----
 1 file changed, 8 insertions(+), 5 deletions(-)
```

Generated by Discord Codex Runner for task #5.