### PR TITLE
Safe tool initialization path handling and parsing tests

### DIFF
--- a/api/tools/core.go
+++ b/api/tools/core.go
@@ -9,6 +9,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -19,8 +22,23 @@ var ResponseTool = &goAgent.Tool{}
 
 // todo refactor so that we add more fields to engine interface
 func init() {
-	goAgent.InitTool(SearchTool, "search.json", initSearch)
-	goAgent.InitTool(ResponseTool, "respond.json", PrintResponse)
+	goAgent.InitTool(SearchTool, resolveToolConfigPath("search.json"), initSearch)
+	goAgent.InitTool(ResponseTool, resolveToolConfigPath("respond.json"), PrintResponse)
+}
+
+func resolveToolConfigPath(name string) string {
+	if _, err := os.Stat(name); err == nil {
+		return name
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return name
+	}
+	rootRelative := filepath.Join(filepath.Dir(thisFile), "..", "..", name)
+	if _, err := os.Stat(rootRelative); err == nil {
+		return rootRelative
+	}
+	return name
 }
 
 func PrintResponse(response map[string]interface{}, chat *goAgent.Chat) (map[string]interface{}, error) {
@@ -40,8 +58,7 @@ type DuckDuckGo struct {
 }
 
 func (d DuckDuckGo) Trace() *search.Trace {
-
-	panic("implement me")
+	return search.NewTrace("", "")
 }
 
 func (d DuckDuckGo) Search(query string, page int) ([]*search.Result, error) {

--- a/api/tools/core_test.go
+++ b/api/tools/core_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import "testing"
+
+func TestParsePageNumber(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     interface{}
+		want    int
+		wantErr bool
+	}{
+		{name: "empty defaults to one", raw: "", want: 1},
+		{name: "valid number", raw: "3", want: 3},
+		{name: "invalid string", raw: "abc", wantErr: true},
+		{name: "invalid type", raw: 2, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePageNumber(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeQueries(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     interface{}
+		want    []string
+		wantErr bool
+	}{
+		{name: "slice interface", raw: []interface{}{"a", "b"}, want: []string{"a", "b"}},
+		{name: "slice string", raw: []string{"a", "b"}, want: []string{"a", "b"}},
+		{name: "json list string", raw: `["a","b"]`, want: []string{"a", "b"}},
+		{name: "single quoted list", raw: `['a','b']`, want: []string{"a", "b"}},
+		{name: "stringified json list", raw: `"[\"a\",\"b\"]"`, want: []string{"a", "b"}},
+		{name: "invalid string", raw: `abc`, wantErr: true},
+		{name: "invalid type", raw: 10, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeQueries(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got len=%d, want len=%d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got[%d]=%q, want[%d]=%q", i, got[i], i, tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/helper.go
+++ b/helper.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -164,7 +166,7 @@ func ChunkByTokens(text string, limit int) []string {
 }
 
 func InitTool(tool *Tool, fileName string, function func(map[string]interface{}, *Chat) (map[string]interface{}, error)) {
-	toolJson, err := os.Open(fileName)
+	toolJson, err := os.Open(resolveToolPath(fileName))
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -177,6 +179,28 @@ func InitTool(tool *Tool, fileName string, function func(map[string]interface{},
 	if function != nil {
 		tool.Function.FunctionCall = function
 	}
+}
+
+func resolveToolPath(fileName string) string {
+	if _, err := os.Stat(fileName); err == nil {
+		return fileName
+	}
+	_, callerFile, _, ok := runtime.Caller(2)
+	if !ok {
+		return fileName
+	}
+	callerDir := filepath.Dir(callerFile)
+	candidates := []string{
+		filepath.Join(callerDir, fileName),
+		filepath.Join(callerDir, "..", fileName),
+		filepath.Join(callerDir, "..", "..", fileName),
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return fileName
 }
 
 func LoadTool(file *os.File, tool *Tool) error {


### PR DESCRIPTION
## Runner Result
- Branch: codex/orch-7-agent-03-safe-update-implementation
- Status: Arc-Tech pushed this task branch and created or updated this pull request after Codex completed.

## Codex Notes
Implemented a safe modernization slice focused on reliability and testability with minimal behavior change.

Changed files:
- [api/tools/core.go](/home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/worktrees/orch-7-agent-3-safe-update-implementation/api/tools/core.go)
- [helper.go](/home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/worktrees/orch-7-agent-3-safe-update-implementation/helper.go)
- [api/tools/core_test.go](/home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/worktrees/orch-7-agent-3-safe-update-implementation/api/tools/core_test.go)

What changed:
- Replaced `DuckDuckGo.Trace()` panic path with a safe default trace return.
- Added centralized tool-config path resolution in `InitTool` so JSON tool files load correctly across different working directories (including package test execution).
- Added table-driven unit tests for:
  - `parsePageNumber`
  - `normalizeQueries`

Tests run:
- `go test ./...` (pass)

Known risks:
- Path resolution now uses caller-based fallback heuristics; if project layout changes significantly, additional path candidates may be needed.

## Task
You are child implementation agent 3 for Excalidraw orchestration #7.

Agent name:
Safe Update Implementation

Role:
tester

Objective:
Apply safe modernization changes in water for this repo is old please upgrade it.

Master plan:
Modernize water for "this repo is old please upgrade it" using project-scoped agents working in /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/repo.

Shared context:
Project: water
Repo path: /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/repo
Remote: https://github.com/EdersenC/goAgent.git
Worktrees: /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/worktrees
The Arc-Tech runner is only the execution harness. Agents must inspect and modify the selected project repository.
Planning decisions: Audit first; Small PRs

Integration strategy:
Use isolated branches/worktrees for water; start with repository discovery, then apply narrow modernization changes and run available validation commands.

Depends on:
Repository Audit

Expected files:
README.md
package.json
src/
app/

Acceptance criteria:
- Changes apply to water, not the Arc-Tech runner repository.
- The assigned slice is implemented with minimal unrelated refactors.
- Relevant build/test/validation commands are run when available and reported in the summary.

Branch:
codex/orch-7-agent-03-safe-update-implementation

Detailed prompt:
Implement the "Safe Update Implementation" slice for orchestration #7.

Project: water

Repo path: /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/repo

Remote: https://github.com/EdersenC/goAgent.git

Parent goal: this repo is old please upgrade it

Selected planning decisions:
- Audit first
- Small PRs

Scope: Apply safe modernization changes in water for this repo is old please upgrade it.

Inspect the actual repository before editing. Keep changes focused on this slice and avoid touching sibling-owned areas unless required for build correctness.

Rules:
- Work only on your assigned objective.
- Avoid unrelated refactors.
- Keep changes mergeable with sibling agents.
- Do not merge your branch.
- Do not run git add, git commit, git push, or gh pr create.
- The runner owns committing, pushing, and pull request creation.
- Run relevant tests if available.
- End with a concise completion summary.

Generated by Arc-Tech for task #3.