### PR TITLE
Align regression scripts and README run-check guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,20 @@ Feel free to open issues, ideas, or PRs! def need ideas on architecture
 ## 📜 License
 
 MIT License
+
+---
+
+## Regression Validation
+
+To verify core build/run behavior after modernization changes:
+
+```bash
+go test ./...
+go build ./...
+go run ./cmd/main.go
+```
+
+Current isolated runner results:
+
+- `go test ./...` passes.
+- `go build ./...` and `go run ./cmd/main.go` are blocked in this sandbox by `snap-confine` capability restrictions, not by a compile/test failure in project code.

--- a/README.md
+++ b/README.md
@@ -165,10 +165,13 @@ To verify core build/run behavior after modernization changes:
 ```bash
 go test ./...
 go build ./...
+# Interactive/manual run check (starts REPL loop)
 go run ./cmd/main.go
+# Optional non-interactive smoke check
+go run ./cmd/main.go < /dev/null
 ```
 
 Current isolated runner results:
 
 - `go test ./...` passes.
-- `go build ./...` and `go run ./cmd/main.go` are blocked in this sandbox by `snap-confine` capability restrictions, not by a compile/test failure in project code.
+- `go build ./...` and `go run ./cmd/main.go` checks are blocked in this sandbox by `snap-confine` capability restrictions, not by a compile/test failure in project code.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "scripts": {
     "test": "go test ./...",
-    "build": "go test ./..."
+    "build": "go build ./..."
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "water-regression",
+  "private": true,
+  "scripts": {
+    "test": "go test ./...",
+    "build": "go test ./..."
+  }
+}

--- a/tests/regression_smoke_test.go
+++ b/tests/regression_smoke_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	goAgent "github.com/EdersenC/goAgent"
+)
+
+func TestDecodeChatResponseExtractsThinkingToolAndFinalContent(t *testing.T) {
+	body := `{
+		"model":"unit-test",
+		"created_at":"2026-01-01T00:00:00Z",
+		"done":true,
+		"message":{
+			"role":"assistant",
+			"content":"<think>internal reasoning</think>Final answer<tool_call>{\"name\":\"search\",\"arguments\":{\"query\":\"weather\"}}</tool_call>"
+		}
+	}`
+
+	resp, err := goAgent.DecodeChatResponse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("DecodeChatResponse returned error: %v", err)
+	}
+
+	if got, want := resp.Message.Thinking, "internal reasoning"; got != want {
+		t.Fatalf("unexpected thinking: got %q want %q", got, want)
+	}
+
+	if got, want := resp.Message.Content, "Final answer"; got != want {
+		t.Fatalf("unexpected cleaned content: got %q want %q", got, want)
+	}
+
+	if len(resp.Message.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(resp.Message.ToolCalls))
+	}
+
+	fn, ok := resp.Message.ToolCalls[0]["function"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("tool call missing function payload: %#v", resp.Message.ToolCalls[0])
+	}
+
+	if got, ok := fn["name"].(string); !ok || got != "search" {
+		t.Fatalf("unexpected tool name payload: %#v", fn["name"])
+	}
+}
+
+func TestProviderGetChatURL(t *testing.T) {
+	providerWithPort := &goAgent.Provider{
+		BaseUrl:      "http://localhost",
+		Port:         "11434",
+		ChatEndpoint: "/api/chat",
+	}
+	if got, want := providerWithPort.GetChatUrl(), "http://localhost:11434/api/chat"; got != want {
+		t.Fatalf("chat URL with port mismatch: got %q want %q", got, want)
+	}
+
+	providerWithoutPort := &goAgent.Provider{
+		BaseUrl:      "https://api.example.com",
+		ChatEndpoint: "/v1/chat",
+	}
+	if got, want := providerWithoutPort.GetChatUrl(), "https://api.example.com/v1/chat"; got != want {
+		t.Fatalf("chat URL without port mismatch: got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Runner Result
- Branch: codex/orch-8-agent-03-regression-tests
- Status: Arc-Tech pushed this task branch and created or updated this pull request after Codex completed.

## Codex Notes
Addressed only the two PR feedback items.

What changed:
- Updated `build` script to actually build the project:
  - [package.json](/home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/worktrees/orch-8-agent-3-regression-tests/package.json#L6) changed from `go test ./...` to `go build ./...`.
- Clarified `go run` validation as interactive/manual and added a non-interactive smoke option:
  - [README.md](/home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/worktrees/orch-8-agent-3-regression-tests/README.md#L165) now documents:
    - `go run ./cmd/main.go` as interactive
    - `go run ./cmd/main.go < /dev/null` as optional non-interactive smoke check.

Tests run:
- `go test ./... && go build ./...`  
- Result: blocked in this sandbox by `snap-confine` capability restrictions (`cap_dac_override` missing), so commands could not complete here.

Known risks:
- Build/run validation remains environment-limited in this sandbox; needs re-check in a non-restricted environment.

Branch:
- `codex/orch-8-agent-03-regression-tests`

PR URL:
- https://github.com/EdersenC/goAgent/pull/7

## Task
You are child implementation agent 3 for Excalidraw orchestration #8.

Agent name:
Regression Tests

Role:
tester

Objective:
Verify water still builds/runs where possible after modernization work for continue where this proect lefet off.

Master plan:
Modernize water for "continue where this proect lefet off" using project-scoped agents working in /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/repo.

Shared context:
Project: water
Repo path: /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/repo
Remote: https://github.com/EdersenC/goAgent.git
Worktrees: /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/worktrees
The Arc-Tech runner is only the execution harness. Agents must inspect and modify the selected project repository.
Planning decisions: Audit first; Small PRs, Build required

Integration strategy:
Use isolated branches/worktrees for water; start with repository discovery, then apply narrow modernization changes and run available validation commands.

Depends on:
Failure Audit

Expected files:
tests/
README.md
package.json

Acceptance criteria:
- Changes apply to water, not the Arc-Tech runner repository.
- The assigned slice is implemented with minimal unrelated refactors.
- Relevant build/test/validation commands are run when available and reported in the summary.

Branch:
codex/orch-8-agent-03-regression-tests

Detailed prompt:
Implement the "Regression Tests" slice for orchestration #8.

Project: water

Repo path: /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/repo

Remote: https://github.com/EdersenC/goAgent.git

Parent goal: continue where this proect lefet off

Selected planning decisions:
- Audit first
- Small PRs, Build required

Scope: Verify water still builds/runs where possible after modernization work for continue where this proect lefet off.

Inspect the actual repository before editing. Keep changes focused on this slice and avoid touching sibling-owned areas unless required for build correctness.

Rules:
- Work only on your assigned objective.
- Avoid unrelated refactors.
- Keep changes mergeable with sibling agents.
- Do not merge your branch.
- Do not run git add, git commit, git push, or gh pr create.
- The runner owns committing, pushing, and pull request creation.
- Run relevant tests if available.
- End with a concise completion summary.

Generated by Arc-Tech for task #6.