### PR TITLE
Limit error-body reads and sync chat tool registry consistently

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -3,7 +3,6 @@ package goAgent
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"time"
@@ -294,7 +293,9 @@ func (c *Chat) SendMessage(role, content string, stream bool) (*ChatResponse, er
 	if c.Agent.Provider == nil {
 		return nil, fmt.Errorf("chat agent provider is nil")
 	}
-	if c.Agent.Tools == nil {
+	if c.ToolRegistry != nil {
+		c.Agent.Tools = c.ToolRegistry
+	} else if c.Agent.Tools == nil {
 		c.Agent.Tools = NewToolRegistry()
 	}
 	url := c.Agent.Provider.GetChatUrl()
@@ -326,8 +327,8 @@ func (c *Chat) SendMessage(role, content string, stream bool) (*ChatResponse, er
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("chat request failed with status %d: %s", resp.StatusCode, string(body))
+		bodyPreview := readBodyPreview(resp.Body, maxErrorBodyPreviewBytes)
+		return nil, fmt.Errorf("chat request failed with status %d: %s", resp.StatusCode, bodyPreview)
 	}
 
 	chatResponse, err := DecodeChatResponse(resp.Body)

--- a/agents.go
+++ b/agents.go
@@ -3,6 +3,7 @@ package goAgent
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -224,6 +225,12 @@ func (a *Agent) Embed(content string) ([]*EmbeddedContent, error) {
 }
 
 func (a *Agent) EmbedChunk(content string) (*EmbeddedContent, error) {
+	if a == nil {
+		return nil, fmt.Errorf("agent is nil")
+	}
+	if a.Provider == nil {
+		return nil, fmt.Errorf("agent provider is nil")
+	}
 	url := a.Provider.getEmbeddingUrl()
 
 	payload := map[string]interface{}{
@@ -281,6 +288,15 @@ func (a *Agent) AsTool(functionCall func(map[string]interface{}, *Chat) (map[str
 
 // SendMessage sends a message to the agent and returns the response.
 func (c *Chat) SendMessage(role, content string, stream bool) (*ChatResponse, error) {
+	if c == nil || c.Agent == nil {
+		return nil, fmt.Errorf("chat or chat agent is nil")
+	}
+	if c.Agent.Provider == nil {
+		return nil, fmt.Errorf("chat agent provider is nil")
+	}
+	if c.Agent.Tools == nil {
+		c.Agent.Tools = NewToolRegistry()
+	}
 	url := c.Agent.Provider.GetChatUrl()
 
 	c.AddMessage(role, content)
@@ -305,6 +321,13 @@ func (c *Chat) SendMessage(role, content string, stream bool) (*ChatResponse, er
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error sending request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("chat request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	chatResponse, err := DecodeChatResponse(resp.Body)

--- a/api/search/Search.go
+++ b/api/search/Search.go
@@ -17,8 +17,14 @@ func (r *Result) ScrapeContentInto() error {
 	if !strings.HasPrefix(r.URL, "https://") {
 		return fmt.Errorf("skipping non-HTTPS URL: %s", r.URL)
 	}
+	if goAgent.EmbeddingAgent == nil {
+		return fmt.Errorf("embedding agent is not configured")
+	}
 
-	req, _ := http.NewRequest("GET", r.URL, nil)
+	req, err := http.NewRequest("GET", r.URL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create scrape request: %w", err)
+	}
 	req.Header.Set("User-Agent", "Mozilla/5.0")
 
 	client := &http.Client{Timeout: 10 * time.Second}
@@ -32,6 +38,10 @@ func (r *Result) ScrapeContentInto() error {
 
 		}
 	}(resp.Body)
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("scrape request failed with status %d", resp.StatusCode)
+	}
 
 	doc, err := goquery.NewDocumentFromReader(resp.Body)
 	if err != nil {

--- a/api/search/model.go
+++ b/api/search/model.go
@@ -69,6 +69,9 @@ type Result struct {
 }
 
 func (r *Result) FormatDuration() string {
+	if r == nil || r.Summary == nil {
+		return "0ms"
+	}
 	if r.Summary.Duration <= 0 {
 		return "0ms"
 	}

--- a/api/tools/core.go
+++ b/api/tools/core.go
@@ -51,7 +51,10 @@ func (d DuckDuckGo) Search(query string, page int) ([]*search.Result, error) {
 		"s": {fmt.Sprintf("%d", offset)},
 	}
 
-	req, _ := http.NewRequest("POST", "https://html.duckduckgo.com/html/", strings.NewReader(data.Encode()))
+	req, err := http.NewRequest("POST", "https://html.duckduckgo.com/html/", strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create search request: %w", err)
+	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", "Mozilla/5.0")
 
@@ -68,6 +71,10 @@ func (d DuckDuckGo) Search(query string, page int) ([]*search.Result, error) {
 
 		}
 	}(resp.Body)
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("duckduckgo request failed with status %d", resp.StatusCode)
+	}
 
 	doc, err := goquery.NewDocumentFromReader(resp.Body)
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,9 @@ func init() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	defer func() {
+		_ = agentsFolder.Close()
+	}()
 	toolRegistry = goAgent.NewToolRegistry()
 	err = goAgent.LoadAgents(agentsFolder, &agents)
 	if err != nil {

--- a/helper.go
+++ b/helper.go
@@ -66,6 +66,28 @@ var (
 	reTool  = regexp.MustCompile(`(?s)<tool_call>.*?</tool_call>`)
 )
 
+const maxErrorBodyPreviewBytes = 2048
+
+func readBodyPreview(body io.Reader, limit int64) string {
+	if body == nil || limit <= 0 {
+		return ""
+	}
+	limited := io.LimitReader(body, limit+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return ""
+	}
+	truncated := int64(len(data)) > limit
+	if truncated {
+		data = data[:limit]
+	}
+	preview := strings.TrimSpace(string(data))
+	if truncated {
+		return preview + "...(truncated)"
+	}
+	return preview
+}
+
 // Returns cleaned message content with <think> and <tool_call> blocks removed (no side effects).
 func (cr *ChatResponse) ExtractFinalContent() string {
 	content := cr.Message.Content
@@ -135,7 +157,8 @@ func doRequest(req *http.Request) ([]byte, error) {
 		return nil, fmt.Errorf("error reading response: %w", err)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		bodyPreview := readBodyPreview(bytes.NewReader(body), maxErrorBodyPreviewBytes)
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, bodyPreview)
 	}
 	return body, nil
 }

--- a/helper.go
+++ b/helper.go
@@ -134,6 +134,9 @@ func doRequest(req *http.Request) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading response: %w", err)
 	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
 	return body, nil
 }
 


### PR DESCRIPTION
## Runner Result
- Branch: codex/orch-8-agent-02-stability-fixes
- Status: Arc-Tech pushed this task branch and created or updated this pull request after Codex completed.

## Codex Notes
Implemented the PR feedback only, with minimal scope in the current worktree/branch.

What changed:
- Limited non-2xx error body logging in `doRequest` to a bounded preview (2KB), with truncation marker.
- Limited non-2xx error body logging in `Chat.SendMessage` to the same bounded preview.
- Fixed tool-registry sync in `Chat.SendMessage`:
  - If `c.ToolRegistry` is present, `c.Agent.Tools` now uses it.
  - Falls back to `NewToolRegistry()` only when both are absent.
- Removed now-unused `io` import from `agents.go`.

Files changed:
- [helper.go](/home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/worktrees/orch-8-agent-2-stability-fixes/helper.go)
- [agents.go](/home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/worktrees/orch-8-agent-2-stability-fixes/agents.go)

Tests run:
- `go test ./...` passed.

Known risks:
- Error preview truncation is byte-limited (2KB), so very large non-2xx bodies are intentionally abbreviated.
- No behavioral refactor beyond the requested feedback fixes.

Branch:
- `codex/orch-8-agent-02-stability-fixes`

PR URL:
- https://github.com/EdersenC/goAgent/pull/8

## Task
You are child implementation agent 2 for Excalidraw orchestration #8.

Agent name:
Stability Fixes

Role:
implementer

Objective:
Apply safe modernization changes in water for continue where this proect lefet off.

Master plan:
Modernize water for "continue where this proect lefet off" using project-scoped agents working in /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/repo.

Shared context:
Project: water
Repo path: /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/repo
Remote: https://github.com/EdersenC/goAgent.git
Worktrees: /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/worktrees
The Arc-Tech runner is only the execution harness. Agents must inspect and modify the selected project repository.
Planning decisions: Audit first; Small PRs, Build required

Integration strategy:
Use isolated branches/worktrees for water; start with repository discovery, then apply narrow modernization changes and run available validation commands.

Depends on:
Failure Audit

Expected files:
tests/
README.md
package.json

Acceptance criteria:
- Changes apply to water, not the Arc-Tech runner repository.
- The assigned slice is implemented with minimal unrelated refactors.
- Relevant build/test/validation commands are run when available and reported in the summary.

Branch:
codex/orch-8-agent-02-stability-fixes

Detailed prompt:
Implement the "Stability Fixes" slice for orchestration #8.

Project: water

Repo path: /home/eddy/.arc-tech/excalidraw-workspaces/excalidraw/water-water/repo

Remote: https://github.com/EdersenC/goAgent.git

Parent goal: continue where this proect lefet off

Selected planning decisions:
- Audit first
- Small PRs, Build required

Scope: Apply safe modernization changes in water for continue where this proect lefet off.

Inspect the actual repository before editing. Keep changes focused on this slice and avoid touching sibling-owned areas unless required for build correctness.

Rules:
- Work only on your assigned objective.
- Avoid unrelated refactors.
- Keep changes mergeable with sibling agents.
- Do not merge your branch.
- Do not run git add, git commit, git push, or gh pr create.
- The runner owns committing, pushing, and pull request creation.
- Run relevant tests if available.
- End with a concise completion summary.

Generated by Arc-Tech for task #5.